### PR TITLE
Replace Google Analytics ga.js tracker script with updated analytics.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,16 +194,14 @@
 
   <script src="https://unpkg.com/github-api/dist/GitHub.bundle.min.js"></script>
   <script src="https://apis.google.com/js/platform.js" async defer></script>
-  <script type="text/javascript">
-    var _gaq = _gaq || [];
-    _gaq.push(['_setAccount', 'UA-28377374-7']);
-    _gaq.push(['_trackPageview']);
-  
-    (function() {
-      var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-      ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-      var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-    })();
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+    ga('create', 'UA-28377374-7', 'auto');
+    ga('send', 'pageview');
   </script>
   <script src="javascript/github.js"></script>
   <script src="javascript/site.js"></script>


### PR DESCRIPTION
Saw that a deprecated library was in use. Didn't notice any specific custom variables or timeout behavior, so simply swapped in new code snippet with Coursera property id.

If the emphasis is on users on newer modern browsers, can implement alternative asynchronous tracking snippet that supports preloading as per https://developers.google.com/analytics/devguides/collection/analyticsjs/

Fixes #1 